### PR TITLE
Fix spaces in contact names to better match voice input

### DIFF
--- a/app/src/main/java/com/f1x/mtcdialer/PhoneBookActivity.java
+++ b/app/src/main/java/com/f1x/mtcdialer/PhoneBookActivity.java
@@ -48,9 +48,10 @@ public abstract class PhoneBookActivity extends BluetoothServiceActivity {
     private void buildPhoneBook(List<String> phoneBookRecords) {
         for(String phoneBookRecord : phoneBookRecords) {
             String[] parsedRecord = phoneBookRecord.split("\\^");
+            String contactName = parsedRecord[0].replaceAll("\\s+", " ").replaceAll("\\s+$", "");
             String phoneNumber = parsedRecord[1].replaceAll("[^\\d\\+]", "");
 
-            mPhoneBookRecords.put(parsedRecord[0], phoneNumber);
+            mPhoneBookRecords.put(contactName, phoneNumber);
         }
     }
 


### PR DESCRIPTION
I don't know how/why but I have lots of contacts with trailing spaces in my phone book.
With this fix I am able to call all those contacts...